### PR TITLE
Login context

### DIFF
--- a/particigator-instructor/src/App.js
+++ b/particigator-instructor/src/App.js
@@ -1,6 +1,6 @@
 import './App.css';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
-import React, {useState} from 'react'
+import React, {useState, useEffect} from 'react'
 import { LoginContext } from './LoginContext';
 import Header from './components/Header';
 import Login from './components/Login';
@@ -10,6 +10,12 @@ import Assignments from './components/Assignments';
 
 function App() {
   const [loggedIn, setLoggedIn] = useState(false);
+
+  useEffect(() => {
+    if(localStorage.getItem('loggedIn')){
+      setLoggedIn(true)
+    }
+  }, [])
 
   return (
     <div className="App">

--- a/particigator-instructor/src/App.js
+++ b/particigator-instructor/src/App.js
@@ -1,6 +1,7 @@
 import './App.css';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import React, {useState} from 'react'
+import { LoginContext } from './LoginContext';
 import Header from './components/Header';
 import Login from './components/Login';
 import Home from './components/Home';
@@ -12,15 +13,17 @@ function App() {
 
   return (
     <div className="App">
-      <Header />
-      <Router>
-        <Routes>
-          <Route path="/" element={<Home loggedIn={loggedIn} />} />
-          <Route path="/login" element={<Login loggedIn={loggedIn} setLoggedIn={setLoggedIn} />} />
-          <Route path="/assignments" element={<Assignments loggedIn={loggedIn} />} />
-          <Route path="/grades" element={<Grades loggedIn={loggedIn} />} />
-        </Routes>
-      </Router>
+      <LoginContext.Provider value={{loggedIn, setLoggedIn}}>
+        <Header />
+        <Router>
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/assignments" element={<Assignments />} />
+            <Route path="/grades" element={<Grades />} />
+          </Routes>
+        </Router>
+      </LoginContext.Provider>
     </div>
   );
 }

--- a/particigator-instructor/src/LoginContext.js
+++ b/particigator-instructor/src/LoginContext.js
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const LoginContext = createContext("");

--- a/particigator-instructor/src/components/Assignments.js
+++ b/particigator-instructor/src/components/Assignments.js
@@ -1,7 +1,12 @@
 import { Navigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { LoginContext } from '../LoginContext';
 import NavBar from './NavBar';
 
-function Assignments({loggedIn}) {
+function Assignments() {
+
+	const {loggedIn} = useContext(LoginContext);
+
 	if (!loggedIn) {
 		return <Navigate to="/login" />
 	}

--- a/particigator-instructor/src/components/Grades.js
+++ b/particigator-instructor/src/components/Grades.js
@@ -1,7 +1,12 @@
 import { Navigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { LoginContext } from '../LoginContext';
 import NavBar from './NavBar';
 
-function Grades({loggedIn}) {
+function Grades() {
+
+	const {loggedIn} = useContext(LoginContext);
+
 	if (!loggedIn) {
 		return <Navigate to="/login" />
 	}

--- a/particigator-instructor/src/components/Home.js
+++ b/particigator-instructor/src/components/Home.js
@@ -1,7 +1,12 @@
 import { Navigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { LoginContext } from '../LoginContext';
 import NavBar from './NavBar';
 
-function Home({loggedIn}) {
+function Home() {
+
+	const {loggedIn} = useContext(LoginContext);
+
 	if (!loggedIn) {
 		return <Navigate to="/login" />
 	}

--- a/particigator-instructor/src/components/Login.js
+++ b/particigator-instructor/src/components/Login.js
@@ -31,6 +31,7 @@ function Login() {
     if (password === "Aman") {
       // navigate to home page
       setLoggedIn(true);
+      localStorage.setItem("loggedIn", true);
     }
     else {
       // TODO: incorrect login message

--- a/particigator-instructor/src/components/Login.js
+++ b/particigator-instructor/src/components/Login.js
@@ -1,8 +1,11 @@
-import React, {useState} from 'react';
+import React, {useState, useContext} from 'react';
 import { Navigate } from 'react-router-dom';
+import { LoginContext } from '../LoginContext';
 import './Login.css';
 
-function Login({loggedIn, setLoggedIn}) {
+function Login() {
+
+  const {loggedIn, setLoggedIn} = useContext(LoginContext);
 
   // set up states for email/password
   const [email, setEmail] = useState("");

--- a/particigator-instructor/src/components/NavBar.js
+++ b/particigator-instructor/src/components/NavBar.js
@@ -1,9 +1,18 @@
 import React, {useState} from 'react'
 import { Link } from 'react-router-dom'
+import { useContext } from 'react';
+import { LoginContext } from '../LoginContext';
 import "./NavBar.css"
 
 
 function NavBar() {
+
+  const {setLoggedIn} = useContext(LoginContext);
+
+  function logout() {
+    setLoggedIn(false);
+    localStorage.removeItem('loggedIn');
+  }
 
   return (
     <div className = "navbar">
@@ -11,6 +20,7 @@ function NavBar() {
             <Link to="/">Home</Link>
             <Link to="/assignments">Assignments</Link>
             <Link to="/grades">Grades</Link>
+            <button onClick={logout}>Log out</button>
         </div>
     </div>
   )


### PR DESCRIPTION
Change loggedIn to be a React Context instead of a State. Use local storage to maintain loggedIn context through page refreshes and closing/reopening the page.

Local storage currently holds a placeholder boolean value instead of an encrypted/hashed authentication token.